### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.nuspec
+++ b/MakoIoT.Device.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot device</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.44.15980" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
     </dependencies>
   </metadata>

--- a/Tests/MakoIoT.Device.Test/MakoIoT.Device.Test.nfproj
+++ b/Tests/MakoIoT.Device.Test/MakoIoT.Device.Test.nfproj
@@ -34,7 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.43.29288\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.44.15980\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/MakoIoT.Device.Test/packages.config
+++ b/Tests/MakoIoT.Device.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.44.15980" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device/MakoIoT.Device.nfproj
+++ b/src/MakoIoT.Device/MakoIoT.Device.nfproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.43.29288\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.44.15980\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device/packages.config
+++ b/src/MakoIoT.Device/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.44.15980" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.43.29288 to 1.0.44.15980</br>
[version update]

### :warning: This is an automated update. :warning:
