### PR TITLE
Update MakoIoT.Device.Services.Interface package and implement IDeviceInitializationBehavior

### DIFF
--- a/Mako-IoT.Device.sln
+++ b/Mako-IoT.Device.sln
@@ -12,7 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		azure-pipelines.yml = azure-pipelines.yml
 		Directory.Build.props = Directory.Build.props
 		LICENSE.md = LICENSE.md
-		nuget.config = nuget.config
 		MakoIoT.Device.nuspec = MakoIoT.Device.nuspec
 		README.md = README.md
 		version.json = version.json

--- a/MakoIoT.Device.nuspec
+++ b/MakoIoT.Device.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot device</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.44.15980" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.45.4694" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
     </dependencies>
   </metadata>

--- a/Tests/MakoIoT.Device.Test/IoTDeviceTests.cs
+++ b/Tests/MakoIoT.Device.Test/IoTDeviceTests.cs
@@ -134,7 +134,6 @@ namespace MakoIoT.Device.Test
 
             // Assert
             Assert.IsTrue(deviceStartBehavior.Executed);
-            // Assert.IsTrue(logger.Logged);
         }
 
         /// <summary>
@@ -171,6 +170,43 @@ namespace MakoIoT.Device.Test
                 var expect = expected[i];
                 var actual = results[i];
 
+                Assert.AreEqual(expect, actual);
+            }
+        }
+        
+        [TestMethod]
+        public void Start_should_execute_multiple_IDeviceInitializationBehavior_in_the_order_they_were_registered()
+        {
+            // Arrange
+            var executions = new ArrayList();
+            var expected = new ArrayList();
+            var random = new Random();
+
+            for (var i = 0; i < 10; i++)
+            {
+                expected.Add(new DeviceInitializationBehaviorMock(random.Next(), true, executions));
+            }
+
+            var serviceCollection = new ServiceCollection();
+            foreach (var deviceStartBehavior in expected)
+            {
+                serviceCollection.AddSingleton(typeof(IDeviceInitializationBehavior), deviceStartBehavior);
+            }
+
+            var sut = new IoTDevice(serviceCollection.BuildServiceProvider(), new MockLogger());
+
+            // Act
+            sut.Start();
+
+            // Assert
+            Assert.AreEqual(expected.Count, executions.Count);
+
+            for (var i = 0; i < executions.Count; i++)
+            {
+                var expect = (DeviceInitializationBehaviorMock) expected[i];
+                var actual = (DeviceInitializationBehaviorMock) executions[i];
+
+                Assert.IsTrue(actual.Executed);
                 Assert.AreEqual(expect, actual);
             }
         }

--- a/Tests/MakoIoT.Device.Test/MakoIoT.Device.Test.nfproj
+++ b/Tests/MakoIoT.Device.Test/MakoIoT.Device.Test.nfproj
@@ -29,13 +29,13 @@
   <ItemGroup>
     <Compile Include="DeviceBuilderTest.cs" />
     <Compile Include="IoTDeviceTests.cs" />
+    <Compile Include="Mocks\DeviceInitializationBehaviorMock.cs" />
     <Compile Include="Mocks\DeviceStartBehaviorMock.cs" />
     <Compile Include="Mocks\MockLogger.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.44.15980\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.45.4694\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>

--- a/Tests/MakoIoT.Device.Test/Mocks/DeviceInitializationBehaviorMock.cs
+++ b/Tests/MakoIoT.Device.Test/Mocks/DeviceInitializationBehaviorMock.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using MakoIoT.Device.Services.Interface;
+
+namespace MakoIoT.Device.Test.Mocks
+{
+    internal class DeviceInitializationBehaviorMock : IDeviceInitializationBehavior
+    {
+        private readonly bool _deviceStartingResult;
+        private readonly ArrayList _executions;
+
+        public DeviceInitializationBehaviorMock(int id, bool deviceStartingResult = true, ArrayList executions = null)
+        {
+            Id = id;
+            _deviceStartingResult = deviceStartingResult;
+            _executions = executions;
+        }
+
+        public bool Executed { get; private set; }
+
+        public int Id { get; }
+
+        public bool DeviceInitialization()
+        {
+            if (_executions is not null)
+            {
+                _executions.Add(this);
+            }
+
+            Executed = true;
+
+            return _deviceStartingResult;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DeviceInitializationBehaviorMock other && Equals(other);
+        }
+
+        protected bool Equals(DeviceInitializationBehaviorMock other)
+        {
+            return Id == other.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(DeviceInitializationBehaviorMock)}.Id: {Id}";
+        }
+    }
+}

--- a/Tests/MakoIoT.Device.Test/packages.config
+++ b/Tests/MakoIoT.Device.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.44.15980" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.45.4694" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device/IoTDevice.cs
+++ b/src/MakoIoT.Device/IoTDevice.cs
@@ -22,6 +22,19 @@ namespace MakoIoT.Device
 
         public void Start()
         {
+            if (IsRegistered(ServiceProvider, typeof(IDeviceInitializationBehavior)))
+            {
+                var behaviors = ServiceProvider.GetServices(typeof(IDeviceInitializationBehavior));
+                foreach (IDeviceInitializationBehavior behavior in behaviors)
+                {
+                    if (!behavior.DeviceInitialization())
+                    {
+                        _logger.Information($"{behavior.GetType().Name} returned false. Bailing!");
+                        return;
+                    }
+                }
+            }
+            
             if (IsRegistered(ServiceProvider, typeof(IDeviceStartBehavior)))
             {
                 var behaviors = ServiceProvider.GetServices(typeof(IDeviceStartBehavior));
@@ -30,7 +43,6 @@ namespace MakoIoT.Device
                     if (!behavior.DeviceStarting())
                     {
                         _logger.Information($"{behavior.GetType().Name} returned false. Bailing!");
-
                         return;
                     }
                 }

--- a/src/MakoIoT.Device/MakoIoT.Device.nfproj
+++ b/src/MakoIoT.Device/MakoIoT.Device.nfproj
@@ -23,9 +23,8 @@
     <Compile Include="IoTDevice.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.44.15980\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.45.4694\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device/packages.config
+++ b/src/MakoIoT.Device/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.44.15980" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.45.4694" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />


### PR DESCRIPTION
The `MakoIoT.Device.Services.Interface` package has been updated to version `1.0.45.4694`. IoTDevice start behavior has been extended to support the execution of multiple `IDeviceInitializationBehavior` in the order they were registered. Corresponding tests have been added to ensure the correct execution flow.