### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.nuspec
+++ b/MakoIoT.Device.nuspec
@@ -18,7 +18,7 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot device</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
     </dependencies>
   </metadata>

--- a/Tests/MakoIoT.Device.Test/MakoIoT.Device.Test.nfproj
+++ b/Tests/MakoIoT.Device.Test/MakoIoT.Device.Test.nfproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>

--- a/Tests/MakoIoT.Device.Test/packages.config
+++ b/Tests/MakoIoT.Device.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="3.0.67" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device/MakoIoT.Device.nfproj
+++ b/src/MakoIoT.Device/MakoIoT.Device.nfproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device/packages.config
+++ b/src/MakoIoT.Device/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.48.22567 to 1.0.50.35966</br>
[version update]

### :warning: This is an automated update. :warning:
